### PR TITLE
Arabic files and translation

### DIFF
--- a/Instructions/HandCreasing/handCreasing_AR.md
+++ b/Instructions/HandCreasing/handCreasing_AR.md
@@ -1,0 +1,200 @@
+﻿---
+layout: page
+title: الحز اليدوي
+tagline: &nbsp <span class="instructionsTaglineEmojiLinks"> <a href="https://youtu.be/a7HmViDaAvk"><i class="em em-video_camera" aria-role="presentation" aria-label="VIDEO CAMERA"></i></a> <a href = "https://github.com/HappyShield/HappyShield/tree/master/Templates/HandCreasing" ><i class="em em-triangular_ruler" aria-role="presentation" aria-label="TRIANGULAR RULER"></i></a></span>
+permalink: /hand-creasing/en/
+---
+
+<i class="em em-timer_clock" aria-role="presentation" aria-label=""></i>: 10-15′
+
+---
+
+<script src="https://snapwidget.com/js/snapwidget.js"></script>
+<iframe src="https://snapwidget.com/embed/810064" class="snapwidget-widget" allowtransparency="true" frameborder="0" scrolling="no" style="border:none; overflow:hidden;  width:100%; "></iframe>
+
+---
+
+---
+
+## Disclaimer
+
+---
+
+The University of Cambridge (UC) and the University of Queensland (UQ) make no warranty of any kind, express or implied, about the design, characteristics, durability, proper use or performance of the HappyShield, including but not limited to implied warranties of merchantability and fitness for any particular purpose. The HappyShield is designed to minimise exposure to fluids and sprays, but UC and UQ do not warrant that HappyShield will protect users from COVID-19 infection or any other infectious disease. Nothing in this material constitutes medical advice, and users should seek their own medical advice about whether HappyShield is suitable for the use they intend, and whether they should use it in conjunction with any other medical or other strategies. To the fullest extent allowed by law, UC and UQ exclude all implied warranties, guarantees, terms and conditions. UC and UQ are not liable for any claims, demands, damages or injuries, including but not limited to property damage, bodily injury or illness, death, indirect, special or consequential damages (“the Claims”) arising out of using the HappyShield, and users of HappyShield release UC and UQ and their officers, employees, contractors and agents from all Claims.
+
+---
+
+## إخلاء مسؤولية 
+ترجمة غير رسمية 
+لا تقدم جامعة كامبريدج (UC) وجامعة كوينزلاند (UQ) أي ضمان من أي نوع ، صريحًا أو ضمنيًا ، بشأن التصميم أو الخصائص أو المتانة أو الاستخدام السليم أو أداء HappyShield ، بما في ذلك على سبيل المثال لا الحصر ضمانات لـ القابلية للتسويق والتقديم لأي غرض معين. تم تصميم HappyShield لتقليل التعرض للسوائل والمبخات ، لكن UC و UQ لا تضمنان أن HappyShield سيحمي المستخدمين من عدوى COVID-19 أو أي مرض معدي آخر. لا يوجد أي شيء في هذا المنتج مما يشكل نصيحة طبية ، ويجب على المستخدمين طلب المشورة الطبية الخاصة بهم حول ما إذا كان HappyShield مناسبًا للاستخدام الذي ينوون القيام به ، وما إذا كان يجب عليهم استخدامه جنبًا إلى جنب مع أي استراتيجيات طبية أو استراتيجيات أخرى. إلى أقصى حد يسمح به القانون ، تستبعد شركة UC و UQ جميع الضمانات الأحكام الخاصة بها. لا تتحمل جامعتي UC و UQ مسؤولية أي مطالبات أو مطالب بأضرار أو إصابات ، بما في ذلك على سبيل المثال لا الحصر ، أضرار الممتلكات أو الإصابة أو المرض الجسدي أو الوفاة أو الأضرار غير المباشرة أو الخاصة أو الناشئة عن استخدام HappyShield ، يعفو مستخدمي  HappyShield   جامعة كامبريدج وجامعة كوينزلاند  مع موظفيهم والمقاولين والوكلاء من جميع المطالبات.
+
+---
+
+
+--- 
+
+## الأدوات
+
+---
+
+* مقص أو مشرط
+* قلم حبر جاف
+* مسطرة
+* سكين زبدة
+* طابعة
+
+
+---
+
+## المواد
+
+---
+
+**غطاء الوجه**
+
+* نصف مم سماكة لوح بت البولي ايثيلين تيريفثاليت,  أو لوح شفاف اسيتات
+* شريط مطاطي بعرض 20 مم . 70 بوليستر 30٪ مطاط
+* شريط لاصق
+
+---
+
+---
+
+# التعليمات
+
+---
+
+# 1 
+
+![](./Assets/Output/Steps/01.jpg)
+
+قم بتحميل المخطط الخاص بغطاء الوجه من موقعنا.  إذا لم تتمكن من الوصول إلى طابعة ، يمكنك رسم المخطط الخاص بك باستخدام الأبعاد الموضحة في الرسمات المذكورة.
+
+---
+
+# 2
+
+![](./Assets/Output/Steps/02.jpg)
+
+ضع الورقة الشفافة على المخطط. ضع علامة على موقع ثقوب الشريط باستخدام قلم التحديد. لا تقلق بشأن الحبر ، يمكن إزالته لاحقاً بقطعة قماش مبللة بالكحول.
+
+---
+
+# 3
+
+![](./Assets/Output/Steps/03.jpg)
+
+قم برسم حدود غطاء الوجه باستخدام القلم أيضاً
+
+---
+
+# 4
+
+![](./Assets/Output/Steps/04.jpg)
+
+قص حدود الغطاء باستخدام مقص أو مشرط. قم أيضاً بفتح ثقوب الشريط المطاطي. يمكنك استخدام خرامة الثقب لعمل هذه الثقوب.
+بعد ذلك ، قص المستطيلات الصغيرة والتي ستقوم بتثبيت الشريط في غطاء الوجه.
+سنقوم بعد ذلك بحز منحيين لطي الغطاء
+
+---
+
+
+
+## طريقة الحز A
+
+---
+
+# 5A
+
+![](./Assets/Output/Steps/05.jpg)
+
+ضع الورقة الشفافة على المخطط وثبتها بشريط لاصق اودبوس ورق.
+
+---
+
+# 6A
+
+![](./Assets/Output/Steps/06.jpg)
+
+باستخدام القلم والمسطرة قم بحز الورقة راسما الخطوط المستقيمة والتي تشكل المنحني وذلك بالضغط على القلم. للقيام بالحز, ربما تحتاج لتعليم الخط ثلاث او اربع مرات.
+---
+
+# 7A
+
+![](./Assets/Output/Steps/07.jpg)
+
+اقلب الورقة الشفافة وثبتها مرة أخرى.
+
+---
+
+# 8A
+
+![](./Assets/Output/Steps/08.jpg)
+
+ تتبع المنحنى الثاني بنفس الطريقة كما في الخطوة  قبل السابقة
+
+---
+
+## Creasing Method B
+
+---
+
+# 5B	
+
+![](./Assets/Output/Steps/09.jpg)
+
+تتبع المنحنيات المرسومة باستخدام قلم. لايلزم ضغط اضافي على القلم هنا قم فقط برسم المنحني
+
+---
+
+# 6B
+
+![](./Assets/Output/Steps/10.jpg)
+
+ستحتاج في هذه الطريقة لقناة (مجراية) بعمق 2-5 مم وعرض 2-3 مم وطول 5 سم. يمكنك عملها من قطعة من الخشب. كما يمكنك استخدامالفراغات الموجودة بين الواح الخشب في أرضية المنزل, او في طاولة الطعام او المطبخ, أي قناة باعاد مشابهة للتي ذكرناها سابقاً يمكن أن تعمل. 
+بعد ذلك ، باستخدام اي اداة ذات حرف غير حاد, سكين زبدة أو قلم جاف, قم بتحديد وحز المنحني وذلك بتثبيت اليد التي تحمل القلم ولف الغطاء وتحريكه في اليد الأخرى.
+
+---
+
+# 7B
+
+![](./Assets/Output/Steps/11.jpg)
+
+قم بقلب غطاء الوجه 
+
+---
+
+# 8B
+
+![](./Assets/Output/Steps/12.jpg)
+
+كرر العملية كما في الخطوة  قبل السابقة
+
+---
+
+# 9
+
+![](./Assets/Output/Steps/13.jpg)
+
+قم بطي الغطاء, ابدأ من نهاية منحني الحز, اصغط برفق على طرفي الغطاء وقم بالطي حتى النهاية الاخرى للمنحني. في حال كانت بعض الاجزاء غير سهلة في طيها, كرر اجراء الحز في هذا الجزء. 
+
+---
+
+# 10
+
+![](./Assets/Output/Steps/14.jpg)
+
+كرر الخطوة 9 لمنحنى الحز الآخر ، ولكن هذه المرة ، قم بطي الورقة في الاتجاه الآخر.
+
+---
+
+# 11	
+
+![](./Assets/Output/Steps/15.jpg)
+
+مرر الشريط من خلال مستطيلات التثبيت. مرر المستطيلات عبر الفتحات الموجودة في غطاء من الجانب الخلفي إلى الأمام.
+
+
+
+
+

--- a/Instructions/HandCreasing/handCreasing_AR.md
+++ b/Instructions/HandCreasing/handCreasing_AR.md
@@ -2,7 +2,8 @@
 layout: page
 title: الحز اليدوي
 tagline: &nbsp <span class="instructionsTaglineEmojiLinks"> <a href="https://youtu.be/a7HmViDaAvk"><i class="em em-video_camera" aria-role="presentation" aria-label="VIDEO CAMERA"></i></a> <a href = "https://github.com/HappyShield/HappyShield/tree/master/Templates/HandCreasing" ><i class="em em-triangular_ruler" aria-role="presentation" aria-label="TRIANGULAR RULER"></i></a></span>
-permalink: /hand-creasing/en/
+permalink: /hand-creasing/ar/
+language: ar
 ---
 
 <i class="em em-timer_clock" aria-role="presentation" aria-label=""></i>: 10-15′

--- a/Instructions/LaserCut/laserCut_AR.md
+++ b/Instructions/LaserCut/laserCut_AR.md
@@ -2,7 +2,8 @@
 layout: page
 title: القص بالليزر 
 tagline: &nbsp <span class="instructionsTaglineEmojiLinks"><a href = "https://github.com/HappyShield/HappyShield/tree/master/Templates/LaserCut" ><i class="em em-triangular_ruler" aria-role="presentation" aria-label="TRIANGULAR RULER"></i></a></span>
-permalink: /laser-cut/en/
+permalink: /laser-cut/ar/
+language: ar
 ---
 
 <script src="https://snapwidget.com/js/snapwidget.js"></script>

--- a/Instructions/LaserCut/laserCut_AR.md
+++ b/Instructions/LaserCut/laserCut_AR.md
@@ -1,0 +1,87 @@
+﻿---
+layout: page
+title: القص بالليزر 
+tagline: &nbsp <span class="instructionsTaglineEmojiLinks"><a href = "https://github.com/HappyShield/HappyShield/tree/master/Templates/LaserCut" ><i class="em em-triangular_ruler" aria-role="presentation" aria-label="TRIANGULAR RULER"></i></a></span>
+permalink: /laser-cut/en/
+---
+
+<script src="https://snapwidget.com/js/snapwidget.js"></script>
+<iframe src="https://snapwidget.com/embed/811086" class="snapwidget-widget" allowtransparency="true" frameborder="0" scrolling="no" style="border:none; overflow:hidden;  width:100%; "></iframe>
+
+---
+
+## Disclaimer
+
+---
+
+The University of Cambridge (UC) and the University of Queensland (UQ) make no warranty of any kind, express or implied, about the design, characteristics, durability, proper use or performance of the HappyShield, including but not limited to implied warranties of merchantability and fitness for any particular purpose. The HappyShield is designed to minimise exposure to fluids and sprays, but UC and UQ do not warrant that HappyShield will protect users from COVID-19 infection or any other infectious disease. Nothing in this material constitutes medical advice, and users should seek their own medical advice about whether HappyShield is suitable for the use they intend, and whether they should use it in conjunction with any other medical or other strategies. To the fullest extent allowed by law, UC and UQ exclude all implied warranties, guarantees, terms and conditions. UC and UQ are not liable for any claims, demands, damages or injuries, including but not limited to property damage, bodily injury or illness, death, indirect, special or consequential damages (“the Claims”) arising out of using the HappyShield, and users of HappyShield release UC and UQ and their officers, employees, contractors and agents from all Claims.
+
+---
+
+---
+
+## إخلاء مسؤولية 
+ترجمة غير رسمية
+لا تقدم جامعة كامبريدج (UC) وجامعة كوينزلاند (UQ) أي ضمان من أي نوع ، صريحًا أو ضمنيًا ، بشأن التصميم أو الخصائص أو المتانة أو الاستخدام السليم أو أداء HappyShield ، بما في ذلك على سبيل المثال لا الحصر ضمانات لـ القابلية للتسويق والتقديم لأي غرض معين. تم تصميم HappyShield لتقليل التعرض للسوائل والمبخات ، لكن UC و UQ لا تضمنان أن HappyShield سيحمي المستخدمين من عدوى COVID-19 أو أي مرض معدي آخر. لا يوجد أي شيء في هذا المنتج مما يشكل نصيحة طبية ، ويجب على المستخدمين طلب المشورة الطبية الخاصة بهم حول ما إذا كان HappyShield مناسبًا للاستخدام الذي ينوون القيام به ، وما إذا كان يجب عليهم استخدامه جنبًا إلى جنب مع أي استراتيجيات طبية أو استراتيجيات أخرى. إلى أقصى حد يسمح به القانون ، تستبعد شركة UC و UQ جميع الضمانات الأحكام الخاصة بها. لا تتحمل جامعتي UC و UQ مسؤولية أي مطالبات أو مطالب بأضرار أو إصابات ، بما في ذلك على سبيل المثال لا الحصر ، أضرار الممتلكات أو الإصابة أو المرض الجسدي أو الوفاة أو الأضرار غير المباشرة أو الخاصة أو الناشئة عن استخدام HappyShield ، يعفو مستخدمي  HappyShield   جامعة كامبريدج وجامعة كوينزلاند  مع موظفيهم والمقاولين والوكلاء من جميع المطالبات.
+
+---
+
+--- 
+
+## الادوات
+---
+
+* قاطع ليزري
+* مقص او مشرط
+
+---
+
+## المواد
+
+---
+
+**غطاء الوجه**
+
+* نصف مم سماكة لوح بت البولي ايثيلين تيريفثاليت,  أو لوح شفاف اسيتات
+* شريط مطاطي بعرض 20 مم . 70 بوليستر 30٪ مطاط
+
+
+---
+
+---
+
+# التعليمات
+
+---
+
+# 1
+
+![](./Assets/Output/Steps/01.jpg)
+
+قم بتنزيل مخطط قص الليزر من موقعنا.  قم بقص اللوح البلاستيكي الشفاف باستخدام بالليزر ، تأكد أن إعدادات طاقة وسرعة القاطع بالليزر مناسبة لعمق ونوع المادة. 
+
+---
+
+# 2	
+
+![](./Assets/Output/Steps/02.jpg)
+
+قم بطي الغطاء, ابدأ من نهاية منحني الحز, اصغط برفق على طرفي الغطاء وقم بالطي حتى النهاية الاخرى للمنحني 
+
+--- 
+
+# 3 	
+
+![](./Assets/Output/Steps/03.jpg)
+
+كرر الخطوة 9 لمنحنى الحز الآخر ، ولكن هذه المرة ، قم بطي الورقة في الاتجاه الآخر
+
+---
+
+# 4	
+
+![](./Assets/Output/Steps/04.jpg)
+
+مرر الشريط من خلال مستطيلات التثبيت. مرر المستطيلات عبر الفتحات الموجودة في غطاء من الجانب الخلفي إلى الأمام.
+
+

--- a/Instructions/LaserCutAndPressureCreasing/laserCutAndPressureCreasing_AR.md
+++ b/Instructions/LaserCutAndPressureCreasing/laserCutAndPressureCreasing_AR.md
@@ -1,0 +1,139 @@
+﻿---
+layout: page
+title: مكبس مع مقص ليزري
+tagline: &nbsp <span class="instructionsTaglineEmojiLinks"> <a href = "https://youtu.be/cbJfRK5AS-o"><i class="em em-video_camera" aria-role="presentation" aria-label="VIDEO CAMERA"></i></a> <a href = "https://github.com/HappyShield/HappyShield/tree/master/Templates/LaserCutAndPressureCreasing" ><i class="em em-triangular_ruler" aria-role="presentation" aria-label="TRIANGULAR RULER"></i></a></span>
+permalink: /pressure-creasing/en/
+---
+
+<script src="https://snapwidget.com/js/snapwidget.js"></script>
+<iframe src="https://snapwidget.com/embed/810066" class="snapwidget-widget" allowtransparency="true" frameborder="0" scrolling="no" style="border:none; overflow:hidden;  width:100%; "></iframe>
+
+---
+
+## Disclaimer
+
+---
+
+The University of Cambridge (UC) and the University of Queensland (UQ) make no warranty of any kind, express or implied, about the design, characteristics, durability, proper use or performance of the HappyShield, including but not limited to implied warranties of merchantability and fitness for any particular purpose. The HappyShield is designed to minimise exposure to fluids and sprays, but UC and UQ do not warrant that HappyShield will protect users from COVID-19 infection or any other infectious disease. Nothing in this material constitutes medical advice, and users should seek their own medical advice about whether HappyShield is suitable for the use they intend, and whether they should use it in conjunction with any other medical or other strategies. To the fullest extent allowed by law, UC and UQ exclude all implied warranties, guarantees, terms and conditions. UC and UQ are not liable for any claims, demands, damages or injuries, including but not limited to property damage, bodily injury or illness, death, indirect, special or consequential damages (“the Claims”) arising out of using the HappyShield, and users of HappyShield release UC and UQ and their officers, employees, contractors and agents from all Claims.
+
+---
+
+---
+
+## إخلاء مسؤولية 
+ترجمة غير رسمية
+لا تقدم جامعة كامبريدج (UC) وجامعة كوينزلاند (UQ) أي ضمان من أي نوع ، صريحًا أو ضمنيًا ، بشأن التصميم أو الخصائص أو المتانة أو الاستخدام السليم أو أداء HappyShield ، بما في ذلك على سبيل المثال لا الحصر ضمانات لـ القابلية للتسويق والتقديم لأي غرض معين. تم تصميم HappyShield لتقليل التعرض للسوائل والمبخات ، لكن UC و UQ لا تضمنان أن HappyShield سيحمي المستخدمين من عدوى COVID-19 أو أي مرض معدي آخر. لا يوجد أي شيء في هذا المنتج مما يشكل نصيحة طبية ، ويجب على المستخدمين طلب المشورة الطبية الخاصة بهم حول ما إذا كان HappyShield مناسبًا للاستخدام الذي ينوون القيام به ، وما إذا كان يجب عليهم استخدامه جنبًا إلى جنب مع أي استراتيجيات طبية أو استراتيجيات أخرى. إلى أقصى حد يسمح به القانون ، تستبعد شركة UC و UQ جميع الضمانات الأحكام الخاصة بها. لا تتحمل جامعتي UC و UQ مسؤولية أي مطالبات أو مطالب بأضرار أو إصابات ، بما في ذلك على سبيل المثال لا الحصر ، أضرار الممتلكات أو الإصابة أو المرض الجسدي أو الوفاة أو الأضرار غير المباشرة أو الخاصة أو الناشئة عن استخدام HappyShield ، يعفو مستخدمي  HappyShield   جامعة كامبريدج وجامعة كوينزلاند  مع موظفيهم والمقاولين والوكلاء من جميع المطالبات.
+
+--- 
+
+---
+
+## الادوات
+
+---
+
+* قاطع ليزري
+* مكبس 10 طن
+* كماشة قادرة على قطع حبل أسلاك الفولاذ 1 مم
+* مقص أو مشرط
+* مثقاب أو مفك البراغي
+
+---
+
+## المواد
+
+---
+
+**القالب , من ثلاث قطع**
+
+* 4 ملم خشب MDF
+* أسلاك الفولاذ 1 مم   
+* 6-20 مم براغي خشبية
+* لاصق بلاستيكي شفاف
+
+**غطاء الوجه**
+	
+* نصف مم سماكة لوح بت البولي ايثيلين تيريفثاليت,  أو لوح شفاف اسيتات
+* شريط مطاطي بعرض 20 مم . 70 بوليستر 30٪ مطاط
+
+---
+
+---
+
+# التعليمات
+---
+
+## القالب الخاص بالمكبس  
+
+---
+
+# 1 	
+
+![](./Assets/Output/Steps/01.jpg)
+
+قم بتنزيل مخططات القص الخاصة بالليزر للقالب الذي قمنا بتصميمه. قمنا بتصميم عدة مخططات حسب مساحة المكابس, قم باختيار المخطط المناسب للمكبس الخاص بك. قم بقص الواح الخشب الثلاثة والخاصة بقالب بالليزر. 
+
+---
+
+# 2
+
+![](./Assets/Output/Steps/02.jpg)
+
+قم بقطع وتثبت السلك الفولاذي  باستخدام اللاصق على المنحيات التي رسمتها الى الليزر على الخشب في الالوح أ و ج
+تأكد من عدم كون السلك أطول من الخط المتقطع المرسوم وأن يكون السلك مثتب جيداً وبشكل دقيق على المنحني. 
+
+---
+
+# 3
+
+![](./Assets/Output/Steps/03.jpg)
+
+ثبت الجزء ب  باعلى جزء أ  باستخدام البراغي.
+قم الآن بتثبيت هذين الجزئين على المكبس بالطريقة التي تراها مناسبة لتوزيع الضغط عن الكبس بشكل متساوي على المنحنيات. 
+قم الآن بتثبيت الجزء ج
+
+
+--- 
+
+## غطاء الوجه
+
+---
+
+# 1
+
+![](./Assets/Output/Steps/04.jpg)
+
+قم بتنزيل مخطط قص الليزر الذي يتناسب مع سرير آلة القص بالليزر الخاصة بك. أبعاد المخططات موجودة في أسماء الملفات
+
+---
+
+# 2	
+
+![](./Assets/Output/Steps/05.jpg)
+
+قم بقص اللوح البلاستيكي الشفاف باستخدام بالليزر ، تأكد أن إعدادات طاقة وسرعة القاطع بالليزر مناسبة لعمق ونوع المادة. 
+بعد القص ، قم بإزالة الأغطية ومستطيلات التثبيت الناتجة من سرير قص الليزر. إذا رغبت في ذلك ، امسح الحواف بالكحول ، أو اغسلها بأي صابون لإزالة أي بقايا قطع بالليزر من البلاستيك.
+
+--- 
+
+# 3
+
+![](./Assets/Output/Steps/06.jpg)
+
+ قم بادخال غطاء الوجه المقصوص على القالب في المكبس وقم بالضغط
+
+---
+
+# 4	
+
+![](./Assets/Output/Steps/07.jpg)
+
+قم بقص الشريط المطاطي بطول 400 مم. مرر الشريط من خلال مستطيلات التثبيت.
+
+---
+
+# 5	
+
+![](./Assets/Output/Steps/08.jpg)
+
+مرر المستطيلات عبر الفتحات الموجودة في غطاء من الجانب الخلفي إلى الأمام.

--- a/Instructions/LaserCutAndPressureCreasing/laserCutAndPressureCreasing_AR.md
+++ b/Instructions/LaserCutAndPressureCreasing/laserCutAndPressureCreasing_AR.md
@@ -2,7 +2,8 @@
 layout: page
 title: مكبس مع مقص ليزري
 tagline: &nbsp <span class="instructionsTaglineEmojiLinks"> <a href = "https://youtu.be/cbJfRK5AS-o"><i class="em em-video_camera" aria-role="presentation" aria-label="VIDEO CAMERA"></i></a> <a href = "https://github.com/HappyShield/HappyShield/tree/master/Templates/LaserCutAndPressureCreasing" ><i class="em em-triangular_ruler" aria-role="presentation" aria-label="TRIANGULAR RULER"></i></a></span>
-permalink: /pressure-creasing/en/
+permalink: /pressure-creasing/ar/
+language: ar
 ---
 
 <script src="https://snapwidget.com/js/snapwidget.js"></script>

--- a/Instructions/WaveShield/Waveshield_AR.md
+++ b/Instructions/WaveShield/Waveshield_AR.md
@@ -1,0 +1,128 @@
+﻿---
+layout: page
+title: WaveSHIELD
+tagline: &nbsp <span class="instructionsTaglineEmojiLinks"> <a href=""><i class="em em-video_camera" aria-role="" ><i class="em em-triangular_ruler" aria-role="presentation" aria-label="TRIANGULAR RULER"></i></a></span>
+permalink: /wave-shield/en/
+---
+
+<i class="em em-timer_clock" aria-role="presentation" aria-label=""></i>: 10-15′
+
+---
+
+---
+
+## Disclaimer
+
+---
+
+The University of Cambridge (UC) and the University of Queensland (UQ) make no warranty of any kind, express or implied, about the design, characteristics, durability, proper use or performance of the HappyShield, including but not limited to implied warranties of merchantability and fitness for any particular purpose. The HappyShield is designed to minimise exposure to fluids and sprays, but UC and UQ do not warrant that HappyShield will protect users from COVID-19 infection or any other infectious disease. Nothing in this material constitutes medical advice, and users should seek their own medical advice about whether HappyShield is suitable for the use they intend, and whether they should use it in conjunction with any other medical or other strategies. To the fullest extent allowed by law, UC and UQ exclude all implied warranties, guarantees, terms and conditions. UC and UQ are not liable for any claims, demands, damages or injuries, including but not limited to property damage, bodily injury or illness, death, indirect, special or consequential damages (“the Claims”) arising out of using the HappyShield, and users of HappyShield release UC and UQ and their officers, employees, contractors and agents from all Claims.
+
+---
+
+---
+
+## إخلاء مسؤولية 
+ترجمة غير رسمية
+لا تقدم جامعة كامبريدج (UC) وجامعة كوينزلاند (UQ) أي ضمان من أي نوع ، صريحًا أو ضمنيًا ، بشأن التصميم أو الخصائص أو المتانة أو الاستخدام السليم أو أداء HappyShield ، بما في ذلك على سبيل المثال لا الحصر ضمانات لـ القابلية للتسويق والتقديم لأي غرض معين. تم تصميم HappyShield لتقليل التعرض للسوائل والمبخات ، لكن UC و UQ لا تضمنان أن HappyShield سيحمي المستخدمين من عدوى COVID-19 أو أي مرض معدي آخر. لا يوجد أي شيء في هذا المنتج مما يشكل نصيحة طبية ، ويجب على المستخدمين طلب المشورة الطبية الخاصة بهم حول ما إذا كان HappyShield مناسبًا للاستخدام الذي ينوون القيام به ، وما إذا كان يجب عليهم استخدامه جنبًا إلى جنب مع أي استراتيجيات طبية أو استراتيجيات أخرى. إلى أقصى حد يسمح به القانون ، تستبعد شركة UC و UQ جميع الضمانات الأحكام الخاصة بها. لا تتحمل جامعتي UC و UQ مسؤولية أي مطالبات أو مطالب بأضرار أو إصابات ، بما في ذلك على سبيل المثال لا الحصر ، أضرار الممتلكات أو الإصابة أو المرض الجسدي أو الوفاة أو الأضرار غير المباشرة أو الخاصة أو الناشئة عن استخدام HappyShield ، يعفو مستخدمي  HappyShield   جامعة كامبريدج وجامعة كوينزلاند  مع موظفيهم والمقاولين والوكلاء من جميع المطالبات.
+
+--- 
+
+--- 
+
+## الادوات
+
+---
+
+
+* مقص أو مشرط
+* قلم حبر جاف
+
+
+---
+
+## المواد
+
+---
+
+**غطاء الوجه**
+
+* نصف مم سماكة لوح بت البولي ايثيلين تيريفثاليت,  أو لوح شفاف اسيتات
+* شريط مطاطي بعرض 20 مم . 70 بوليستر 30٪ مطاط
+* شريط لاصق
+
+
+---
+
+---
+
+# التعليمات
+
+---
+
+# 1 
+
+![](./Assets/Output/Steps/01.jpg)
+
+قم بتحميل المخطط الخاص بغطاء الوجه من موقعنا.  إذا لم تتمكن من الوصول إلى طابعة ، يمكنك رسم المخطط الخاص بك باستخدام الأبعاد الموضحة في الرسمات المذكورة.
+
+---
+
+# 2
+
+![](./Assets/Output/Steps/02.jpg)
+
+ضع الورقة الشفافة على المخطط. وثبتها 
+
+---
+
+# 3
+
+![](./Assets/Output/Steps/03.jpg)
+
+ضع علامة على موقع الثقوب بقلم حبر جاف. لا تقلق بشأن الحبر ، يمكن إزالته بقطعة قماش مبللة بالكحول. ضع علامة على الخطوط والزوايا السفلية لقصها لاحقاً.
+
+---
+
+# 4
+
+![](./Assets/Output/Steps/04.jpg)
+
+باستخدام المقص أو المشرط قم بقطع الالواح وتقليم زوايا الغطاء. سيتنج لديك خمس اواح 
+
+---
+
+
+# 5
+
+![](./Assets/Output/Steps/05.jpg)
+
+قم بقطع الثقوب. يمكنك استخدام مثقب الورق أو الجلد إذا كان لديك.
+
+---
+
+# 6
+
+![](./Assets/Output/Steps/06.jpg)
+
+ثبت بالشريط اللاصق اللوحين 1 و 2. تحقق من الشكل المشابه للموجة للوحين عند محاذاة الثقوب فيها. يجب أن يكون هذا الشكل متناظر قد الامكان.
+
+---
+
+# 7
+
+![](./Assets/Output/Steps/07.jpg)
+
+ثبت بيدك كل الالواح مع بعضها. الترتيب من الداخل إلى الخارج: 1 ثم 2 ثم 3 ثم غطاء الوجه ثم الغطاء اعلوي. قم بمحاذاة الثقوب معًا. اربط الالواح بشريط مطاطي. يجب أن يدخل من الثقوب في المنطقة العلوية ويخرج من الثقوب في المنطقة السفلية.
+
+---
+
+# 8
+
+![](./Assets/Output/Steps/08.jpg)
+
+كرر في الجانب المقابل. 
+
+---
+
+
+

--- a/Instructions/WaveShield/Waveshield_AR.md
+++ b/Instructions/WaveShield/Waveshield_AR.md
@@ -2,7 +2,8 @@
 layout: page
 title: WaveSHIELD
 tagline: &nbsp <span class="instructionsTaglineEmojiLinks"> <a href=""><i class="em em-video_camera" aria-role="" ><i class="em em-triangular_ruler" aria-role="presentation" aria-label="TRIANGULAR RULER"></i></a></span>
-permalink: /wave-shield/en/
+permalink: /wave-shield/ar/
+language: ar
 ---
 
 <i class="em em-timer_clock" aria-role="presentation" aria-label=""></i>: 10-15′


### PR DESCRIPTION
We might have trouble to the right to left format in Arabic, hebrew etc. I did a light googling https://stackoverflow.com/questions/2258028/rtl-in-markdown
Here is one seems-to-simple suggestion:

"""Actually as my friend Aevyz reminded me, Markdown parses HTML in it.

You won't need to change your parser. The quickest path to solve that I could think of is this:

<div dir="rtl">

سلام دنیا

مرحبا العالم

שלום בעולם

ہیلو دنیا
</div>
So you need to add literally two lines to turn a whole document RTL, and by the way it will be better compatible than an own script. So i think this is an answer to the question.""""